### PR TITLE
On error page delete stored partition and queue

### DIFF
--- a/src/app/components/error-view/error-view.component.spec.ts
+++ b/src/app/components/error-view/error-view.component.spec.ts
@@ -19,17 +19,32 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MatCardModule} from '@angular/material/card';
 import {RouterTestingModule} from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
 
 import {ErrorViewComponent} from './error-view.component';
+import {CommonUtil} from '@app/utils/common.util';
+import { MockNgxSpinnerService } from '@app/testing/mocks';
+import { NgxSpinnerService } from 'ngx-spinner';
 
 describe('ErrorViewComponent', () => {
   let component: ErrorViewComponent;
   let fixture: ComponentFixture<ErrorViewComponent>;
 
-  beforeAll(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [MatCardModule, RouterTestingModule],
       declarations: [ErrorViewComponent],
+      providers: [
+        { provide: NgxSpinnerService, useValue: MockNgxSpinnerService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParams: {}
+            }
+          }
+        }
+      ],
     }).compileComponents();
   });
 
@@ -41,5 +56,11 @@ describe('ErrorViewComponent', () => {
 
   it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should clear stored queue and partition on init', () => {
+    const setStoredQueueSpy = spyOn(CommonUtil, 'setStoredQueueAndPartition');
+    component.ngOnInit();
+    expect(setStoredQueueSpy).toHaveBeenCalledWith('');
   });
 });

--- a/src/app/components/error-view/error-view.component.ts
+++ b/src/app/components/error-view/error-view.component.ts
@@ -18,6 +18,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { CommonUtil } from '@app/utils/common.util';
 import { ApiErrorInfo } from '@app/models/api-error-info.model';
 
 @Component({
@@ -34,6 +35,7 @@ export class ErrorViewComponent implements OnInit {
   ngOnInit() {
     this.apiError = window.history.state;
     this.lastActiveUrl = this.activatedRoute.snapshot.queryParams['last'];
+    CommonUtil.setStoredQueueAndPartition('');
   }
 
   retryLastActiveUrlAgain() {


### PR DESCRIPTION
### What is this PR for?
Fixes an issue with stored queue and partition. When the page is reloaded and that info is gone page will crash. On the error page, that info will be removed from storage

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring
